### PR TITLE
update node-fetch to version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "babel-runtime": "6.x.x",
-    "node-fetch": "^1.5.2",
+    "node-fetch": "^2.0.0",
     "whatwg-fetch": "^1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Updates node-fetch to version 2.

A review of the code indicates that none of the breaking changes in the library update require any modifications.